### PR TITLE
feat(node_status_switch): support Reroute nodes for switch connections

### DIFF
--- a/js/node_status_switch.js
+++ b/js/node_status_switch.js
@@ -116,6 +116,23 @@ function readBoolFromNode(node) {
 }
 
 /**
+ * Resolves the true source node by traversing through Reroute nodes.
+ */
+function resolveSourceNode(startNode, graph) {
+    let current = startNode;
+    const visited = new Set();
+    while (current?.type?.includes?.("Reroute") && !visited.has(current.id)) {
+        visited.add(current.id);
+        const linkId = current.inputs?.[0]?.link;
+        const link = linkId != null ? (graph.links?.[linkId] ?? graph._links?.get?.(linkId)) : null;
+        if (!link) break;
+        const allNodes = graph._nodes ?? graph.nodes ?? [];
+        current = allNodes.find((n) => n.id === link.origin_id);
+    }
+    return current;
+}
+
+/**
  * Read the effective "enabled" value at queue time.
  * If the "enabled" input is connected, follow the link to the source
  * node and read its boolean value.  Otherwise fall back to the local
@@ -143,7 +160,7 @@ function readEnabled(switchNode, visited) {
             graph._links?.get?.(enabledInput.link);
         if (link) {
             const allNodes = graph._nodes ?? graph.nodes ?? [];
-            const src = allNodes.find((n) => n.id === link.origin_id);
+            const src = resolveSourceNode(allNodes.find((n) => n.id === link.origin_id), graph);
             if (src) {
                 // If upstream is another switch, use its effective value,
                 // not its raw widget — a chained switch's output is what
@@ -178,7 +195,9 @@ function getTargetNodeIds(switchNode) {
         const link =
             graph.links?.[input.link] ?? graph._links?.get?.(input.link);
         if (link && link.origin_id != null) {
-            ids.push(link.origin_id);
+            const allNodes = graph._nodes ?? graph.nodes ?? [];
+            const src = resolveSourceNode(allNodes.find((n) => n.id === link.origin_id), graph);
+            if (src) ids.push(src.id);
         }
     }
     return ids;
@@ -278,20 +297,24 @@ function findDownstreamSwitches(switchNode, visited) {
     const linkIds = outSlot?.links ?? [];
 
     const found = [];
-    for (const linkId of linkIds) {
-        const link = linksMap?.[linkId] ?? linksMap?.get?.(linkId);
-        if (!link) continue;
-        const target = allNodes.find((n) => n.id === link.target_id);
-        if (!target || target.type !== NODE_TYPE) continue;
-        // Only count it if the link lands on the target's "enabled" input.
-        const tInput = target.inputs?.[link.target_slot];
-        if (!tInput || tInput.name !== "enabled") continue;
+    const traceVisited = new Set();
 
-        found.push(target);
-        // Recurse to catch chains of length > 2.
-        const further = findDownstreamSwitches(target, visited);
-        for (const f of further) found.push(f);
+    function traceDownstream(linkId) {
+        if (traceVisited.has(linkId)) return;
+        traceVisited.add(linkId);
+
+        const link = linksMap?.[linkId] ?? linksMap?.get?.(linkId);
+        const target = link ? allNodes.find((n) => n.id === link.target_id) : null;
+        if (!target) return;
+
+        if (target.type?.includes?.("Reroute")) {
+            (target.outputs?.[0]?.links ?? []).forEach(traceDownstream);
+        } else if (target.type === NODE_TYPE && target.inputs?.[link.target_slot]?.name === "enabled") {
+            found.push(target, ...findDownstreamSwitches(target, visited));
+        }
     }
+
+    linkIds.forEach(traceDownstream);
     return found;
 }
 
@@ -338,7 +361,7 @@ function syncExternalToLocal(switchNode) {
     if (!link) return;
 
     const allNodes = graph._nodes ?? graph.nodes ?? [];
-    const src = allNodes.find((n) => n.id === link.origin_id);
+    const src = resolveSourceNode(allNodes.find((n) => n.id === link.origin_id), graph);
     if (!src) return;
 
     // If the source is another switch, we want its *effective* enabled


### PR DESCRIPTION
## Description
This PR adds support for `Reroute` nodes in the `DaSiWa_NodeStatusSwitch` connections.
Previously, if a `Reroute` node was placed between the switch and a target node (or a boolean source node), the graph traversal logic would fail to resolve the true origin or target. This PR updates the graph tracing logic to seamlessly follow links through any number of `Reroute` nodes, allowing users to keep their wirings clean and organized.
## Changes
- **Upstream Resolution:** Added `resolveSourceNode` to traverse upstream through `Reroute` nodes and correctly discover the true boolean source node.
- **Downstream Tracking:** Updated `findDownstreamSwitches` and related target tracking functions to recursively trace through downstream `Reroute` links via `traceDownstream`.
- **Refactoring:** Applied modern JS syntax (optional chaining `?.`, nullish coalescing `??`, spread operators `...`) to keep the graph traversing logic highly concise and readable.
## Impact
- **Target Connections:** `target_XX` slots now work properly even when wired through one or more `Reroute` nodes.
- **Boolean Source Connections:** The `enabled` input accurately reads the value from the true source node beyond `Reroute` nodes.
- **Chained Switches:** Downstream UI state synchronization correctly traces through `Reroute` nodes.
- **Backward Compatibility:** Direct connections without `Reroute` nodes remain unaffected and work exactly as before.