### PR TITLE
MiniMax H3 Director: stereo WAV references are rejected because packed audio counts double

### DIFF
--- a/.tests/test_minimax_h3_director.py
+++ b/.tests/test_minimax_h3_director.py
@@ -203,6 +203,57 @@ def test_load_audio_applies_timeline_crop(tmp_path):
     assert audio_duration(audio) == 15
 
 
+def _write_packed_stereo_wav(path, seconds, sample_rate=8_000):
+    """Write a PCM s16 stereo file — a packed (interleaved) PyAV sample format."""
+    frames = np.zeros((seconds * sample_rate, 2), dtype=np.int16)
+    with wave.open(str(path), "wb") as output:
+        output.setnchannels(2)
+        output.setsampwidth(2)
+        output.setframerate(sample_rate)
+        output.writeframes(frames.tobytes())
+
+
+def test_load_audio_deinterleaves_packed_stereo(tmp_path):
+    path = tmp_path / "stereo.wav"
+    _write_packed_stereo_wav(path, seconds=10)
+
+    audio = load_audio(path.name, str(tmp_path))
+
+    assert audio["waveform"].shape[1] == 2
+    assert audio_duration(audio) == 10
+
+
+def test_load_audio_crops_packed_stereo_on_real_seconds(tmp_path):
+    path = tmp_path / "stereo.wav"
+    _write_packed_stereo_wav(path, seconds=20)
+
+    audio = load_audio(path.name, str(tmp_path), trim_start=2, trim_end=17)
+
+    assert audio["waveform"].shape[1] == 2
+    assert audio_duration(audio) == 15
+
+
+def test_load_embedded_video_audio_deinterleaves_packed_stereo(tmp_path):
+    av = pytest.importorskip("av")
+    path = tmp_path / "stereo_packed.mkv"
+    sample_rate = 8_000
+    with av.open(str(path), "w") as output:
+        stream = output.add_stream("pcm_s16le", rate=sample_rate)
+        stream.layout = "stereo"
+        for _ in range(10 * sample_rate // 1024):
+            frame = av.AudioFrame.from_ndarray(np.zeros((1, 1024 * 2), dtype=np.int16), format="s16", layout="stereo")
+            frame.sample_rate = sample_rate
+            for packet in stream.encode(frame):
+                output.mux(packet)
+        for packet in stream.encode():
+            output.mux(packet)
+
+    audio = load_embedded_video_audio(path.name, str(tmp_path))
+
+    assert audio["waveform"].shape[1] == 2
+    assert audio_duration(audio) == pytest.approx(10, abs=0.1)
+
+
 def test_load_embedded_video_audio_applies_the_video_crop(tmp_path):
     av = pytest.importorskip("av")
     path = tmp_path / "reference.m4a"

--- a/.tests/test_minimax_h3_director.py
+++ b/.tests/test_minimax_h3_director.py
@@ -203,9 +203,10 @@ def test_load_audio_applies_timeline_crop(tmp_path):
     assert audio_duration(audio) == 15
 
 
-def _write_packed_stereo_wav(path, seconds, sample_rate=8_000):
+def _write_packed_stereo_wav(path, seconds, sample_rate=8_000, frames=None):
     """Write a PCM s16 stereo file — a packed (interleaved) PyAV sample format."""
-    frames = np.zeros((seconds * sample_rate, 2), dtype=np.int16)
+    if frames is None:
+        frames = np.zeros((seconds * sample_rate, 2), dtype=np.int16)
     with wave.open(str(path), "wb") as output:
         output.setnchannels(2)
         output.setsampwidth(2)
@@ -252,6 +253,57 @@ def test_load_embedded_video_audio_deinterleaves_packed_stereo(tmp_path):
 
     assert audio["waveform"].shape[1] == 2
     assert audio_duration(audio) == pytest.approx(10, abs=0.1)
+
+
+def test_load_audio_keeps_full_scale_pcm_inside_the_unit_range(tmp_path):
+    path = tmp_path / "fullscale.wav"
+    sample_rate = 8_000
+    frames = np.tile(np.array([[-32768, 32767]], dtype=np.int16), (3 * sample_rate, 1))
+    _write_packed_stereo_wav(path, seconds=3, sample_rate=sample_rate, frames=frames)
+
+    audio = load_audio(path.name, str(tmp_path))
+
+    assert float(audio["waveform"].abs().max()) <= 1.0
+    assert float(audio["waveform"].min()) == pytest.approx(-1.0, abs=1e-4)
+
+
+def test_load_audio_centres_unsigned_pcm_on_silence(tmp_path):
+    """8-bit PCM is unsigned: its silence sits at 128, not at 0."""
+    path = tmp_path / "unsigned.wav"
+    sample_rate = 8_000
+    with wave.open(str(path), "wb") as output:
+        output.setnchannels(1)
+        output.setsampwidth(1)
+        output.setframerate(sample_rate)
+        output.writeframes(np.full(3 * sample_rate, 128, dtype=np.uint8).tobytes())
+
+    waveform = load_audio(path.name, str(tmp_path))["waveform"]
+
+    assert float(waveform.abs().max()) == pytest.approx(0.0, abs=1e-6)
+
+
+def test_load_embedded_video_audio_keeps_its_amplitude_at_full_scale(tmp_path):
+    """A single -32768 sample must not trip the legacy int16 rescale on the rest."""
+    av = pytest.importorskip("av")
+    path = tmp_path / "fullscale.mkv"
+    sample_rate = 8_000
+    block = np.full((1, 1024), 16_384, dtype=np.int16)
+    block[0, 0] = -32_768
+    with av.open(str(path), "w") as output:
+        stream = output.add_stream("pcm_s16le", rate=sample_rate)
+        stream.layout = "mono"
+        for _ in range(3 * sample_rate // 1024):
+            frame = av.AudioFrame.from_ndarray(block, format="s16", layout="mono")
+            frame.sample_rate = sample_rate
+            for packet in stream.encode(frame):
+                output.mux(packet)
+        for packet in stream.encode():
+            output.mux(packet)
+
+    waveform = load_embedded_video_audio(path.name, str(tmp_path))["waveform"]
+
+    assert float(waveform.abs().max()) <= 1.0
+    assert float(waveform.max()) == pytest.approx(0.5, abs=1e-3)
 
 
 def test_load_embedded_video_audio_applies_the_video_crop(tmp_path):

--- a/nodes/helper_minimax_h3_director.py
+++ b/nodes/helper_minimax_h3_director.py
@@ -196,6 +196,10 @@ def decode_audio_frame(frame) -> np.ndarray:
     single interleaved row for packed ones (s16 — PCM WAV). Left interleaved, a
     stereo clip measures twice its real length and every crop offset lands on
     the wrong sample.
+
+    Integer formats are scaled by their maximum magnitude, not their maximum
+    value, so a full-scale -32768 lands on exactly -1.0 instead of overshooting
+    the unit range.
     """
     samples = frame.to_ndarray()
     if samples.ndim == 1:
@@ -203,8 +207,11 @@ def decode_audio_frame(frame) -> np.ndarray:
     channels = samples.shape[-1] // frame.samples if frame.samples else 1
     if channels > 1 and samples.shape[0] == 1:
         samples = np.ascontiguousarray(samples.reshape(-1, channels).T)
-    if not samples.dtype.kind == "f":
-        samples = samples.astype(np.float32) / np.iinfo(samples.dtype).max
+    if samples.dtype.kind == "u":
+        midpoint = 2.0 ** (8 * samples.dtype.itemsize - 1)
+        samples = (samples.astype(np.float32) - midpoint) / midpoint
+    elif samples.dtype.kind != "f":
+        samples = samples.astype(np.float32) / -float(np.iinfo(samples.dtype).min)
     return samples
 
 
@@ -274,10 +281,9 @@ def load_embedded_video_audio(path: str, input_directory: str, *, trim_start: fl
                 chunks.append(torch.from_numpy(array[:, start:end]).float())
         if not chunks:
             raise ValueError("embedded video audio trim range produced no samples")
-        waveform = torch.cat(chunks, dim=-1)
-        if waveform.dtype.is_floating_point and waveform.abs().max() > 1:
-            waveform /= 32768.0
-        return {"waveform": waveform.unsqueeze(0), "sample_rate": sample_rate}
+        # decode_audio_frame() already returns unit-range floats, so the former
+        # int16 rescale here would only ever fire on correctly scaled audio.
+        return {"waveform": torch.cat(chunks, dim=-1).unsqueeze(0), "sample_rate": sample_rate}
     finally:
         container.close()
 

--- a/nodes/helper_minimax_h3_director.py
+++ b/nodes/helper_minimax_h3_director.py
@@ -189,6 +189,25 @@ def load_image(path: str, input_directory: str):
     return torch.from_numpy(array).unsqueeze(0)
 
 
+def decode_audio_frame(frame) -> np.ndarray:
+    """Return one decoded audio frame as float samples shaped (channels, samples).
+
+    PyAV yields (channels, samples) for planar formats (fltp — MP3, AAC) but a
+    single interleaved row for packed ones (s16 — PCM WAV). Left interleaved, a
+    stereo clip measures twice its real length and every crop offset lands on
+    the wrong sample.
+    """
+    samples = frame.to_ndarray()
+    if samples.ndim == 1:
+        samples = samples[None, :]
+    channels = samples.shape[-1] // frame.samples if frame.samples else 1
+    if channels > 1 and samples.shape[0] == 1:
+        samples = np.ascontiguousarray(samples.reshape(-1, channels).T)
+    if not samples.dtype.kind == "f":
+        samples = samples.astype(np.float32) / np.iinfo(samples.dtype).max
+    return samples
+
+
 def load_audio(path: str, input_directory: str, *, trim_start: float = 0.0,
                trim_end: float | None = None):
     full_path = resolve_input_path(path, input_directory)
@@ -210,11 +229,7 @@ def load_audio(path: str, input_directory: str, *, trim_start: float = 0.0,
             frame_end = timestamp + float(frame.samples) / sample_rate
             if frame_end <= trim_start or (trim_end is not None and timestamp >= trim_end):
                 continue
-            samples = frame.to_ndarray()
-            if samples.ndim == 1:
-                samples = samples[None, :]
-            if not samples.dtype.kind == "f":
-                samples = samples.astype(np.float32) / np.iinfo(samples.dtype).max
+            samples = decode_audio_frame(frame)
             start = max(0, int(round((trim_start - timestamp) * sample_rate)))
             end = samples.shape[-1] if trim_end is None else min(samples.shape[-1], int(round((trim_end - timestamp) * sample_rate)))
             if end > start:
@@ -252,9 +267,7 @@ def load_embedded_video_audio(path: str, input_directory: str, *, trim_start: fl
             frame_end = timestamp + float(frame.samples) / sample_rate
             if frame_end <= trim_start or (trim_end is not None and timestamp >= trim_end):
                 continue
-            array = frame.to_ndarray()
-            if array.ndim == 1:
-                array = array[None, :]
+            array = decode_audio_frame(frame)
             start = max(0, int(round((trim_start - timestamp) * sample_rate)))
             end = array.shape[-1] if trim_end is None else min(array.shape[-1], int(round((trim_end - timestamp) * sample_rate)))
             if end > start:


### PR DESCRIPTION
## The bug

Any stereo PCM WAV used as a REF2VA audio reference is measured at twice its
real length, so the 2–15 second window rejects clips that are well within it:

```
audio 1 must be between 2 and 15 seconds (got 20)
```

for a 10 second file. Under 7.5 s the clip passes validation instead, but
reaches the model interleaved into a single channel — i.e. at double speed —
and every crop offset lands on the wrong sample.

MP3/M4A references are unaffected, which makes the rejection look arbitrary
from the UI.

## Cause

`load_audio()` and `load_embedded_video_audio()` treat `frame.to_ndarray()` as
always shaped `(channels, samples)`. PyAV only returns that for **planar**
sample formats (`fltp` — MP3, AAC, OGG). **Packed** formats (`s16` — PCM WAV,
`flt`, `s32`) come back as one interleaved row, `(1, samples * channels)`:

```python
>>> frame.format.name, frame.format.is_planar, frame.layout.nb_channels
('s16', False, 2)
>>> frame.samples, frame.to_ndarray().shape
(4096, (1, 8192))
```

`audio_duration()` is `waveform.shape[-1] / sample_rate`, hence the doubling on
stereo. Every existing audio test in `.tests/` writes mono, so nothing exercised
this path.

## Fix

`decode_audio_frame()` derives the channel count from `frame.samples`,
de-interleaves packed frames into `(channels, samples)` and normalises integer
formats to float. Both loaders share it. That also fixes a second issue in
`load_embedded_video_audio()`, which never normalised at all and returned
soundtracks at raw int16 amplitude.

## Tests

Three regression tests: a packed stereo WAV keeps its real duration and two
channels, its crop resolves in real seconds, and a packed stereo soundtrack
embedded in a video decodes the same way.

Baseline on `main` (Windows, PyAV 18.0.0, Python 3.12): `7 failed, 131 passed`.
With this branch: `7 failed, 134 passed` — the three new tests pass and no
existing test changes state. The seven pre-existing failures are unrelated to
this change:

- four are `KeyError: 'imd'` on every REF2VA run, the subject of #15;
- three read `js/minimax_h3_director.js` via `Path(...).read_text()` without
  `encoding="utf-8"`, which fails under the Windows cp1252 default. Happy to
  send that one-liner separately if it is welcome.
