### PR TITLE
RTX Upscaler & Refiner: move empty_cache to optional inputs (fixes #24)

### DIFF
--- a/nodes/nodes_rtx_upscaler_refiner.py
+++ b/nodes/nodes_rtx_upscaler_refiner.py
@@ -440,6 +440,8 @@ class DaSiWa_RTX_UpscalerRefiner:
                 "ratio_preset": (COMMON_RATIOS, {"default": "16:9", "description": "Forced aspect ratio (used by 'Preset Ratio')."}),
                 "resize_method": (RESIZE_METHODS, {"default": "Center Crop (Fill)", "description": "Mismatch handling: 'Crop' fills the target area, 'Letterbox' fits inside with black bars."}),
                 "device_id": ("INT", {"default": 0, "min": 0, "max": 8, "step": 1, "description": "GPU Index for RTX VFX computation."}),
+            },
+            "optional": {
                 "empty_cache": ("BOOLEAN", {"default": False, "description": "Run a lightweight GC + empty_cache before allocation; also calls model_management.soft_empty_cache() to ask ComfyUI models to unload, which can free VRAM but may slow subsequent nodes."}),
             },
         }
@@ -480,7 +482,7 @@ class DaSiWa_RTX_UpscalerRefiner:
         ratio_preset,
         resize_method,
         device_id,
-        empty_cache,
+        empty_cache=False,
     ):
         if not torch.cuda.is_available():
             raise RuntimeError("NVIDIA RTX VFX requires CUDA. No CUDA devices found.")


### PR DESCRIPTION
As discussed in #24: e425332 added `empty_cache` as a required input, so API-format workflows exported before 0.4.9 fail validation with `required_input_missing: empty_cache`.

This moves `empty_cache` to the `optional` section (same `False` default, widget unchanged in the UI) and gives `execute` a matching `empty_cache=False` default, since ComfyUI omits absent optional inputs from the call. Old API-format JSON now validates and runs with the pre-0.4.9 behavior; workflows that do set `empty_cache` are unaffected.