### PR TITLE
fix: preview-panel checkboxes (save first/last frame, autoplay) reset on tab switch / reload

### DIFF
--- a/js/enhanced_video_combine_preview.js
+++ b/js/enhanced_video_combine_preview.js
@@ -174,7 +174,11 @@ app.registerExtension({
             saveLastFrameLabel.append(saveLastFrame, " Save last frame");
             const autoPlay = document.createElement("input");
             autoPlay.type = "checkbox";
-            autoPlay.checked = true;
+            this.properties ??= {};
+            autoPlay.checked = this.properties.autoplay ?? true;
+            autoPlay.addEventListener("change", () => {
+                this.properties.autoplay = autoPlay.checked;
+            });
             const autoPlayLabel = document.createElement("label");
             autoPlayLabel.style.cssText = "display:flex;align-items:center;gap:3px;margin-left:auto;white-space:nowrap;cursor:pointer";
             autoPlayLabel.append(autoPlay, " Autoplay");
@@ -251,16 +255,20 @@ app.registerExtension({
             this.dasiwaVideoPreview = preview;
             this.dasiwaVideoPreviewWidget = previewWidget;
             this.dasiwaFrameExportCheckboxes = { save_first_frame: saveFirstFrame, save_last_frame: saveLastFrame };
+            this.dasiwaAutoPlayCheckbox = autoPlay;
             return result;
         };
 
         const originalOnConfigure = nodeType.prototype.onConfigure;
         nodeType.prototype.onConfigure = function () {
             const result = originalOnConfigure ? originalOnConfigure.apply(this, arguments) : undefined;
-            // widgets_values is applied after onNodeCreated built the checkboxes, so
-            // their initial `checked` snapshot predates the restored widget values.
+            // widgets_values / properties are applied after onNodeCreated built the
+            // checkboxes, so their initial `checked` snapshot predates the restored state.
             for (const [name, checkbox] of Object.entries(this.dasiwaFrameExportCheckboxes ?? {})) {
                 checkbox.checked = Boolean(this.widgets?.find((widget) => widget.name === name)?.value);
+            }
+            if (this.dasiwaAutoPlayCheckbox) {
+                this.dasiwaAutoPlayCheckbox.checked = this.properties?.autoplay ?? true;
             }
             return result;
         };

--- a/js/enhanced_video_combine_preview.js
+++ b/js/enhanced_video_combine_preview.js
@@ -250,6 +250,18 @@ app.registerExtension({
             };
             this.dasiwaVideoPreview = preview;
             this.dasiwaVideoPreviewWidget = previewWidget;
+            this.dasiwaFrameExportCheckboxes = { save_first_frame: saveFirstFrame, save_last_frame: saveLastFrame };
+            return result;
+        };
+
+        const originalOnConfigure = nodeType.prototype.onConfigure;
+        nodeType.prototype.onConfigure = function () {
+            const result = originalOnConfigure ? originalOnConfigure.apply(this, arguments) : undefined;
+            // widgets_values is applied after onNodeCreated built the checkboxes, so
+            // their initial `checked` snapshot predates the restored widget values.
+            for (const [name, checkbox] of Object.entries(this.dasiwaFrameExportCheckboxes ?? {})) {
+                checkbox.checked = Boolean(this.widgets?.find((widget) => widget.name === name)?.value);
+            }
             return result;
         };
 


### PR DESCRIPTION
## Summary
Two related persistence bugs on the Enhanced Video Combine node's in-node preview panel — both showed as checkboxes silently reverting after switching workflow tabs or reloading.

**1. Save first frame / Save last frame**
These checkboxes mirror the real (hidden) `save_first_frame`/`save_last_frame` BOOLEAN widgets, built in `onNodeCreated` (`js/enhanced_video_combine_preview.js`). They snapshot the widget's `.value` at construction time — but LiteGraph applies saved `widgets_values` via `configure()` *after* node construction, so the checkbox always renders the INPUT_TYPES default (`false`) regardless of the saved value. This was purely visual — the underlying widget value (and what actually got queued) was unaffected.

**2. Autoplay**
Different root cause: this checkbox isn't backed by any widget at all — it's a bare DOM checkbox hardcoded to `checked = true` on every `onNodeCreated`, so it has nothing to remember and always resets to checked.

## Fix
- Save-first/last-frame: store refs to the checkboxes on the node (`this.dasiwaFrameExportCheckboxes`) and add an `onConfigure` hook that resyncs `checked` from the real widget values once `configure()` has actually run.
- Autoplay: back it with `node.properties.autoplay` (LiteGraph's per-node storage, serialized/restored via `configure()` the same way widgets_values is), persist on change, and resync it from the same `onConfigure` hook.

## Test plan
- [x] Checked both frame-export boxes, switched to another workflow tab and back — stayed checked.
- [x] Unchecked Autoplay, switched tabs and back — stayed unchecked.
- [x] Reloaded the page — all three checkboxes correctly reflect saved state.
- [x] Ran a generation with the frame-export boxes checked — first/last frame PNGs still saved correctly (unaffected by this change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)